### PR TITLE
Fix incorrect grunt command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,16 +1,6 @@
 module.exports = function (grunt) {
 
     grunt.initConfig({
-        run: {
-            npminstall: {
-                options: {
-                    wait: true
-                },
-                cmd: 'npm',
-                args: ['install']
-            }
-        },
-        
         copy: {
             requirejs: {
                 src: './node_modules/requirejs/require.js',
@@ -35,9 +25,8 @@ module.exports = function (grunt) {
         }
     });
 
-    grunt.loadNpmTasks('grunt-run');
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-bowercopy');
 
-    grunt.registerTask('install', ['run:npminstall', 'copy:requirejs', 'bowercopy:libs']);
+    grunt.registerTask('install', ['copy:requirejs', 'bowercopy:libs']);
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "postinstall": "grunt install"
   },
   "dependencies": {
     "body-parser": "~1.16.0",


### PR DESCRIPTION
Remove npm install call from Grunt. Now "grunt install" command that runs "bower install" and copies libs to proper folder is added to npm's package.json "postinstall" script invocation. It means that after every "npm install" call from command line "grunt install" is automatically invoked.